### PR TITLE
Ensure efivarfs directory exists before binding into chroot

### DIFF
--- a/install_bonsai.sh
+++ b/install_bonsai.sh
@@ -828,6 +828,7 @@ EOF
     fi
 
     mkdir -p /mnt/sys/firmware/efi
+    mkdir -p "$chroot_efivars"
     if ! mountpoint -q "$chroot_efivars"; then
       echo -e "${CNT} ${BONSAI_TEXT}Binding efivarfs into the chroot environment...${BONSAI_RESET}"
       if ! mount --bind "$host_efivars" "$chroot_efivars"; then


### PR DESCRIPTION
## Summary
- create the /mnt/sys/firmware/efi/efivars directory before bind-mounting efivarfs
- prevent the efivarfs bind from failing when running the installer in UEFI mode

## Testing
- bash tests/systemd_boot_config_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68d113b9b2b4832d9a1abb627f3e2ac4